### PR TITLE
Add Solidity syntax highlight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 rule_descriptions/* linguist-documentation
 *.g4 linguist-generated
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Update `.gitattributes` to enable Solidity syntax highlight on GitHub.